### PR TITLE
allow additional :ets config to be passed in on start up

### DIFF
--- a/lib/mentat.ex
+++ b/lib/mentat.ex
@@ -70,6 +70,7 @@ defmodule Mentat do
   Options:
 
   `:name` - The name of the cache
+  `:ets_args` - Additional arguments to pass to `:ets.new/2`
   `:cleanup_interval` - How often the janitor process will remove old keys (defaults to 5_000).
   """
   def start_link(args) do
@@ -185,7 +186,8 @@ defmodule Mentat do
   def init(args) do
     name     = Keyword.get(args, :name)
     interval = Keyword.get(args, :cleanup_interval, 5_000)
-    ^name    = :ets.new(name, [:set, :named_table, :public])
+    ets_args = Keyword.get(args, :ets_args, [])
+    ^name    = :ets.new(name, [:set, :named_table, :public] ++ ets_args)
 
     children = [
       {Mentat.Janitor, [name: :"#{name}_janitor", interval: interval, cache: name]}

--- a/test/mentat_test.exs
+++ b/test/mentat_test.exs
@@ -47,4 +47,14 @@ defmodule MentatTest do
       assert Mentat.delete(cache, :key) == true
     end
   end
+
+  describe "configuration" do
+    test "additional :ets arguments can be passed via :ets_args" do
+      stop_supervised(Mentat)
+      name = ConcurrentCache
+      start_supervised({Mentat, name: name, ets_args: [read_concurrency: true]})
+      info = :ets.info(name)
+      assert Keyword.fetch!(info, :read_concurrency)
+    end
+  end
 end


### PR DESCRIPTION
Very cool little library! I often find myself using Cachex just because I need ttls, so I am happy to have a more light weight alternative.

I want to be able to configure the ets table a bit more, for example :read_concurrency, or :write_concurrency, so I have added that possibility. Let me know what you think 😄 