### PR TITLE
Add optional limits to caches

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ Mentat.fetch(:my_cache, :key, [ttl: 5_000], fn key ->
 end)
 ```
 
+## Limits
+
+Mentat supports optional limits per cache.
+
+```elixir
+Mentat.start_link(name: LimitedCache, limit: [size: 100])
+```
+
+When the limit is reached, the janitor will asynchronously reclaim a percentage of the keys
+
 ## Installation
 
 ```elixir

--- a/lib/mentat.ex
+++ b/lib/mentat.ex
@@ -31,6 +31,16 @@ defmodule Mentat do
   end)
   ```
 
+  ## Limits
+
+  Mentat supports optional limits per cache.
+
+  ```elixir
+  Mentat.start_link(name: LimitedCache, limit: [size: 100])
+  ```
+
+  When the limit is reached, the janitor will asynchronously reclaim a percentage of the keys
+
   ## Telemetry
 
   Mentat publishes multiple telemetry events.

--- a/lib/mentat/janitor.ex
+++ b/lib/mentat/janitor.ex
@@ -10,6 +10,10 @@ defmodule Mentat.Janitor do
     GenServer.start_link(__MODULE__, args, name: name)
   end
 
+  def reclaim(name, num_of_keys) do
+    GenServer.cast(name, {:reclaim, num_of_keys})
+  end
+
   def init(args) do
     data = %{
       interval: args[:interval],
@@ -19,6 +23,11 @@ defmodule Mentat.Janitor do
     Process.send_after(self(), :clean, data.interval)
 
     {:ok, data}
+  end
+
+  def handle_cast({:reclaim, count}, data) do
+    Mentat.remove_oldest(data.cache, count)
+    {:noreply, data}
   end
 
   def handle_info(:clean, data) do
@@ -38,4 +47,3 @@ defmodule Mentat.Janitor do
     {:noreply, data}
   end
 end
-

--- a/mix.exs
+++ b/mix.exs
@@ -29,6 +29,7 @@ defmodule Mentat.MixProject do
   defp deps do
     [
       {:telemetry, "~> 0.4"},
+      {:nimble_options, "~> 0.2"},
 
       {:credo, "~> 1.3.1", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.19", only: [:dev, :test]}

--- a/mix.lock
+++ b/mix.lock
@@ -6,6 +6,7 @@
   "jason": {:hex, :jason, "1.2.0", "10043418c42d2493d0ee212d3fddd25d7ffe484380afad769a0a38795938e448", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "116747dbe057794c3a3e4e143b7c8390b29f634e16c78a7f59ba75bfa6852e7f"},
   "makeup": {:hex, :makeup, "1.0.1", "82f332e461dc6c79dbd82fbe2a9c10d48ed07146f0a478286e590c83c52010b5", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "49736fe5b66a08d8575bf5321d716bac5da20c8e6b97714fec2bcd6febcfa1f8"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "d4b316c7222a85bbaa2fd7c6e90e37e953257ad196dc229505137c5e505e9eff"},
+  "nimble_options": {:hex, :nimble_options, "0.3.0", "1872911bf50a048f04da26e02704e6aeafc362c2daa7636b6dbfda9492ccfcfa", [:mix], [], "hexpm", "180790a8644fea402452bc15bb54b9bf2c8e5c1fdeb6b39d8072e59c324edf7f"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm", "589b5af56f4afca65217a1f3eb3fee7e79b09c40c742fddc1c312b3ac0b3399f"},
   "telemetry": {:hex, :telemetry, "0.4.1", "ae2718484892448a24470e6aa341bc847c3277bfb8d4e9289f7474d752c09c7f", [:rebar3], [], "hexpm", "4738382e36a0a9a2b6e25d67c960e40e1a2c95560b9f936d8e29de8cd858480f"},
 }

--- a/test/mentat_test.exs
+++ b/test/mentat_test.exs
@@ -48,6 +48,21 @@ defmodule MentatTest do
     end
   end
 
+  describe "touch/2" do
+    test "updates a cache key's inserted_at time", %{cache: cache} do
+      assert Mentat.put(cache, :key, "value") == true
+      now = System.monotonic_time(:millisecond)
+      assert Mentat.touch(cache, :key) == true
+
+      [{:key, _, ts, _}] = :ets.lookup(cache, :key)
+      assert ts >= now
+    end
+
+    test "returns false if the key does not exist", %{cache: cache} do
+      assert Mentat.touch(cache, :key) == false
+    end
+  end
+
   describe "configuration" do
     test "additional :ets arguments can be passed via :ets_args" do
       stop_supervised(Mentat)
@@ -55,6 +70,43 @@ defmodule MentatTest do
       start_supervised({Mentat, name: name, ets_args: [read_concurrency: true]})
       info = :ets.info(name)
       assert Keyword.fetch!(info, :read_concurrency)
+    end
+  end
+
+  describe "limits" do
+    test "caches can have fixed limits" do
+      stop_supervised(Mentat)
+      start_supervised({Mentat, name: LimitCache, limit: [size: 10, reclaim: 0.1]})
+
+      for i <- 0..20 do
+        Mentat.put(LimitCache, i, i)
+        :timer.sleep(10)
+      end
+
+      :timer.sleep(10)
+
+      assert :ets.info(LimitCache, :size) == 10
+      keys = Mentat.keys(LimitCache)
+      assert Enum.sort(keys) == [11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+    end
+
+    test "limits can be configured to reclaim a percentage of keys" do
+      stop_supervised(Mentat)
+      start_supervised({Mentat, name: LimitCache, limit: [size: 10, reclaim: 0.5]})
+
+      for i <- 0..9 do
+        Mentat.put(LimitCache, i, i)
+        :timer.sleep(10)
+      end
+
+      # Exceed the limit and wait for items to be reclaimed
+      Mentat.put(LimitCache, 10, 10)
+
+      :timer.sleep(10)
+
+      assert :ets.info(LimitCache, :size) == 6
+      keys = Mentat.keys(LimitCache)
+      assert Enum.sort(keys) == [5, 6, 7, 8, 9, 10]
     end
   end
 end


### PR DESCRIPTION
Adds an optional "limit" to a cache. If a user puts more items into a cache than specified, the janitor will be kicked off and told to delete a percentage of the oldest keys.