### PR TITLE
Allow use of telemetry above 1.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule Mentat.MixProject do
 
   defp deps do
     [
-      {:telemetry, "~> 0.4"},
+      {:telemetry, "~> 0.4 or ~> 1.0"},
       {:norm, "~> 0.12"},
       {:oath, "~> 0.1"},
 


### PR DESCRIPTION
This fixes dependency issues with newer versions of Phoenix as described in #12.