### PR TITLE
Add spans for get and put operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,19 +58,45 @@ When the limit is reached, the janitor will asynchronously reclaim a percentage 
 
 Mentat publishes multiple telemetry events.
 
-  * `[:mentat, :get]` - executed after retrieving a value from the cache.
+  * `[:mentat, :get, :start]` - executed before retrieving a value from cache
     Measurements are:
 
-    * `:status` - Can be either `:hit` or `:miss` depending on if the key was
-      found in the cache.
+    * `:system_time` - Current system time
+    * `:monotonic_time` - Current monotonic time
 
     Metadata are:
 
       * `:key` - The key requested
       * `:cache` - The cache name
 
-  * `[:mentat, :put]` - executed when putting a key into the cache. No
-    measurements are provided.
+  * `[:mentat, :get, :stop]` - executed before retrieving a value from cache
+    Measurements are:
+
+    * `:duration` - Duration in native units
+    * `:monotonic_time` - Current monotonic time
+
+    Metadata are:
+
+      * `:key` - The key requested
+      * `:cache` - The cache name
+      * `:status` - Can be either `:hit` or `:miss` depending on if the key was found in the cache
+
+  * `[:mentat, :put, :start]` - executed before putting a key into the cache.
+    Measurements are:
+
+    * `:system_time` - Current system time
+    * `:monotonic_time` - Current monotonic time
+
+    Metadata are:
+
+      * `:key` - The key requested
+      * `:cache` - The name of the cache
+
+  * `[:mentat, :put, :stop]` - executed after putting a key into the cache.
+    Measurements are:
+
+    * `:duration` - Current system time
+    * `:monotonic_time` - Current monotonic time
 
     Metadata are:
 

--- a/lib/mentat.ex
+++ b/lib/mentat.ex
@@ -129,29 +129,33 @@ defmodule Mentat do
   end)
   def put(cache, key, value, opts \\ [])
   def put(cache, key, value, opts) do
-    config = get_config(cache)
-    :telemetry.execute([:mentat, :put], %{}, %{key: key, cache: cache})
+    :telemetry.span([:mentat, :put], %{key: key, cache: cache}, fn ->
+      config = get_config(cache)
 
-    now = ms_time(config.clock)
-    ttl = opts[:ttl] || config.ttl
+      # Leaving this telemetry event for legacy support. We should remove eventually.
+      :telemetry.execute([:mentat, :put], %{}, %{key: key, cache: cache})
 
-    if ttl < 0 do
-      raise ArgumentError, "`:ttl` must be greater than 0"
-    end
+      now = ms_time(config.clock)
+      ttl = opts[:ttl] || config.ttl
 
-    true = :ets.insert(cache, {key, value, now, ttl})
+      if ttl < 0 do
+        raise ArgumentError, "`:ttl` must be greater than 0"
+      end
 
-    # If we've reached the limit on the table, we need to purge a number of old
-    # keys. We do this by calling the janitor process and telling it to purge.
-    # This will, in turn call immediately back into the remove_oldest function.
-    # The back and forth here is confusing to follow, but its necessary because
-    # we want to do the purging in a different process.
-    if config.limit != :none && :ets.info(cache, :size) > config.limit.size do
-      count = ceil(config.limit.size * config.limit.reclaim)
-      Janitor.reclaim(janitor(cache), count)
-    end
+      true = :ets.insert(cache, {key, value, now, ttl})
 
-    value
+      # If we've reached the limit on the table, we need to purge a number of old
+      # keys. We do this by calling the janitor process and telling it to purge.
+      # This will, in turn call immediately back into the remove_oldest function.
+      # The back and forth here is confusing to follow, but its necessary because
+      # we want to do the purging in a different process.
+      if config.limit != :none && :ets.info(cache, :size) > config.limit.size do
+        count = ceil(config.limit.size * config.limit.reclaim)
+        Janitor.reclaim(janitor(cache), count)
+      end
+
+      {value, %{key: key, cache: cache}}
+    end)
   end
 
   @doc """
@@ -269,19 +273,22 @@ defmodule Mentat do
   end
 
   defp lookup(cache, key) do
-    config = get_config(cache)
-    now    = ms_time(config.clock)
+    :telemetry.span([:mentat, :get], %{cache: cache, key: key}, fn ->
+      config = get_config(cache)
+      now    = ms_time(config.clock)
 
-    {status, value} =
-      case :ets.lookup(cache, key) do
-        [] -> {:miss, nil}
-        [{^key, _val, ts, ttl}] when is_integer(ttl) and ts + ttl <= now -> {:miss, nil}
-        [{^key, val, _ts, _expire_at}] -> {:hit, val}
-      end
+      {status, value} =
+        case :ets.lookup(cache, key) do
+          [] -> {:miss, nil}
+          [{^key, _val, ts, ttl}] when is_integer(ttl) and ts + ttl <= now -> {:miss, nil}
+          [{^key, val, _ts, _expire_at}] -> {:hit, val}
+        end
 
-    :telemetry.execute([:mentat, :get], %{status: status}, %{key: key, cache: cache})
+      # Leaving this telemetry event for legacy support. We should remove eventually.
+      :telemetry.execute([:mentat, :get], %{status: status}, %{key: key, cache: cache})
 
-    {status, value}
+      {{status, value}, %{key: key, cache: cache, status: status}}
+    end)
   end
 
   defp put_config(cache, config) do


### PR DESCRIPTION
Adds spans for `get` and `put`. This required updating the telemetry dependency.