### PR TITLE
Check the configuration and table size when reclaiming keys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Mentat supports optional limits per cache.
 Mentat.start_link(name: LimitedCache, limit: [size: 100])
 ```
 
-When the limit is reached, the janitor will asynchronously reclaim a percentage of the keys.
+When the limit is reached, the janitor will asynchronously reclaim a percentage of the keys. The janitor will removed the oldest entries first. If multiple entries share a timestamp (they were inserted at the same time) than they are removed by key in ascending order.
 
 ## Telemetry
 

--- a/lib/mentat.ex
+++ b/lib/mentat.ex
@@ -172,8 +172,7 @@ defmodule Mentat do
       # The back and forth here is confusing to follow, but its necessary because
       # we want to do the purging in a different process.
       if config.limit != :none && :ets.info(cache, :size) > config.limit.size do
-        count = ceil(config.limit.size * config.limit.reclaim)
-        Janitor.reclaim(janitor(cache), count)
+        Janitor.reclaim(janitor(cache))
       end
 
       {value, %{key: key, cache: cache}}
@@ -198,6 +197,14 @@ defmodule Mentat do
   @spec delete(name(), key()) :: true
   def delete(cache, key) do
     :ets.delete(cache, key)
+  end
+
+  @doc """
+  Returns the current size of the cache
+  """
+  @spec size(name()) :: pos_integer()
+  def size(cache) do
+    :ets.info(cache, :size)
   end
 
   @doc """
@@ -251,18 +258,14 @@ defmodule Mentat do
 
   @doc false
   def remove_oldest(cache, count) do
-    ms = [{{:_, :_, :"$1", :_}, [], [:"$1"]}]
+    ms = [{{:"$1", :_, :"$2", :_}, [], [{{:"$2", :"$1"}}]}]
     entries = :ets.select(cache, ms)
 
-    oldest =
-      entries
-      |> Enum.sort()
-      |> Enum.take(count)
-      |> List.last()
-
-    delete_ms = [{{:_, :_, :"$1", :_}, [{:"=<", :"$1", oldest}], [true]}]
-
-    :ets.select_delete(cache, delete_ms)
+    entries
+    |> Enum.sort()
+    |> Enum.take(count)
+    |> Enum.map(fn {ts, key} -> :ets.match_delete(cache, {key, :_, ts, :_}) end)
+    |> Enum.count(& &1)
   end
 
   def init(args) do
@@ -317,7 +320,7 @@ defmodule Mentat do
     :persistent_term.put({__MODULE__, cache}, config)
   end
 
-  defp get_config(cache) do
+  def get_config(cache) do
     :persistent_term.get({__MODULE__, cache})
   end
 

--- a/lib/mentat/janitor.ex
+++ b/lib/mentat/janitor.ex
@@ -10,8 +10,8 @@ defmodule Mentat.Janitor do
     GenServer.start_link(__MODULE__, args, name: name)
   end
 
-  def reclaim(name, num_of_keys) do
-    GenServer.cast(name, {:reclaim, num_of_keys})
+  def reclaim(name) do
+    GenServer.cast(name, :reclaim)
   end
 
   def init(args) do
@@ -25,17 +25,30 @@ defmodule Mentat.Janitor do
     {:ok, data}
   end
 
-  def handle_cast({:reclaim, count}, data) do
-    start_time    = System.monotonic_time()
-    removed_count = Mentat.remove_oldest(data.cache, count)
-    end_time      = System.monotonic_time()
-    delta         = end_time - start_time
+  def handle_cast(:reclaim, data) do
+    config = Mentat.get_config(data.cache)
 
-    :telemetry.execute(
-      [:mentat, :janitor, :reclaim],
-      %{duration: delta, total_removed_keys: removed_count},
-      %{cache: data.cache}
-    )
+    # This logic is duplicated from `Mentat.put`. This is because we only
+    # want to send this message from a calling process if there's a reason
+    # to do a reclamation. But, multiple processes might detect this issue
+    # simultaneously. If we don't check again here we will erroneously 
+    # trigger multiple reclamations which can end up removing many more keys
+    # than is intended.
+    if Mentat.size(data.cache) > config.limit.size do
+      start_time    = System.monotonic_time()
+      count = ceil(config.limit.size * config.limit.reclaim)
+
+      removed_count = Mentat.remove_oldest(data.cache, count)
+
+      end_time      = System.monotonic_time()
+      delta         = end_time - start_time
+
+      :telemetry.execute(
+        [:mentat, :janitor, :reclaim],
+        %{duration: delta, total_removed_keys: removed_count},
+        %{cache: data.cache}
+      )
+    end
 
     {:noreply, data}
   end

--- a/test/mentat_test.exs
+++ b/test/mentat_test.exs
@@ -109,12 +109,11 @@ defmodule MentatTest do
 
       for i <- 0..20 do
         Mentat.put(LimitCache, i, i)
-        :timer.sleep(10)
       end
 
       :timer.sleep(10)
 
-      assert :ets.info(LimitCache, :size) == 10
+      assert Mentat.size(LimitCache) == 10
       keys = Mentat.keys(LimitCache, all: true)
       assert Enum.sort(keys) == [11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
     end
@@ -125,7 +124,6 @@ defmodule MentatTest do
 
       for i <- 0..9 do
         Mentat.put(LimitCache, i, i)
-        :timer.sleep(10)
       end
 
       # Exceed the limit and wait for items to be reclaimed
@@ -133,7 +131,7 @@ defmodule MentatTest do
 
       :timer.sleep(10)
 
-      assert :ets.info(LimitCache, :size) == 6
+      assert Mentat.size(LimitCache) == 6
       keys = Mentat.keys(LimitCache, all: true)
       assert Enum.sort(keys) == [5, 6, 7, 8, 9, 10]
     end


### PR DESCRIPTION
This should help resolve an issue where multiple reclamations could remove all of the keys in a cache. I believe @jeffutter pointed this out years ago and it took me a while to get around to thinking about it. This is what burnout does to a person.